### PR TITLE
Support for overriding initial url XSRD lookup (enables logging in with google apps domain without hosting the XSRD information on the domain)

### DIFF
--- a/example-google_apps.php
+++ b/example-google_apps.php
@@ -1,0 +1,25 @@
+<?php
+# Logging in with Google Apps accounts requires setting special identity (and xsrd override), so this example shows how to do it.
+require 'openid.php';
+try {
+    # Change 'localhost' to your domain name.
+    $openid = new LightOpenID('localhost');
+    $openid->xrds_override = array('#^http://example.com/openid\?id=\d+$#', 'https://www.google.com/accounts/o8/site-xrds?hd=example.com');
+    if(!$openid->mode) {
+        if(isset($_GET['login'])) {
+            $openid->identity = 'https://www.google.com/accounts/o8/site-xrds?hd=example.com';
+            header('Location: ' . $openid->authUrl());
+        }
+?>
+<form action="?login" method="post">
+    <button>Login with Google</button>
+</form>
+<?php
+    } elseif($openid->mode == 'cancel') {
+        echo 'User has canceled authentication!';
+    } else {
+        echo 'User ' . ($openid->validate() ? $openid->identity . ' has ' : 'has not ') . 'logged in.';
+    }
+} catch(ErrorException $e) {
+    echo $e->getMessage();
+}

--- a/openid.php
+++ b/openid.php
@@ -23,7 +23,8 @@ class LightOpenID
          , $oauth = array();
     private $identity, $claimed_id;
     protected $server, $version, $trustRoot, $aliases, $identifier_select = false
-            , $ax = false, $sreg = false, $setup_url = null, $headers = array(), $proxy = null;
+            , $ax = false, $sreg = false, $setup_url = null, $headers = array(), $proxy = null
+            , $xrds_override_pattern = array(), $xrds_override_replacement = array();
     static protected $ax_to_sreg = array(
         'namePerson/friendly'     => 'nickname',
         'contact/email'           => 'email',
@@ -81,6 +82,12 @@ class LightOpenID
         case 'trustRoot':
         case 'realm':
             $this->trustRoot = trim($value);
+            break;
+        case 'xrds_override': 
+            list($pattern, $replacement) = $value;
+            $this->xrds_override_pattern = $pattern;
+            $this->xrds_override_replacement = $replacement;
+            break;
         }
     }
 
@@ -478,6 +485,10 @@ class LightOpenID
 
         # A flag to disable yadis discovery in case of failure in headers.
         $yadis = true;
+        
+        # Allow optional regex replacement of url; for example to use Google Apps
+        # as an OpenID provider without touching domain hosting
+        $url = preg_replace($this->xrds_override_pattern, $this->xrds_override_replacement, $url);
 
         # We'll jump a maximum of 5 times, to avoid endless redirections.
         for ($i = 0; $i < 5; $i ++) {


### PR DESCRIPTION
I think this may be useful to other people than just me.  Intended use is to enable corporate SSO without having to change the hosting situation, but I made it flexible so if someone else has a use case where the OpenID Provider uses urls that need to be changed for verification, they can use this too.
