### PR TITLE
Fix discover function not trying to fall back to HTML discovery if yadis failed

### DIFF
--- a/openid.php
+++ b/openid.php
@@ -630,7 +630,6 @@ class LightOpenID
                     $yadis = false;
                     $url = $originalUrl;
                     $content = null;
-                    break;
                 }
                 if ($next) continue;
 


### PR DESCRIPTION
Exiting from the loop prevents it from trying to discover the document as HTML
