### PR TITLE
Don't use get_magic_quotes_gpc anymore.

### DIFF
--- a/openid.php
+++ b/openid.php
@@ -918,7 +918,7 @@ class LightOpenID
             # wants to verify. stripslashes() should solve that problem, but we can't
             # use it when magic_quotes is off.
             $value = $this->data['openid_' . str_replace('.','_',$item)];
-            $params['openid.' . $item] = function_exists('get_magic_quotes_gpc') && get_magic_quotes_gpc() ? stripslashes($value) : $value;
+            $params['openid.' . $item] = $this->data['openid_' . str_replace('.','_',$item)];
 
         }
 


### PR DESCRIPTION
The reason for this is `get_magic_quotes_gpc` is deprecated in PHP ^7.4.0 and breaks a bunch of applications trying to use this library.

Related: https://github.com/SocialiteProviders/Providers/issues/383