### PR TITLE
Fix PHP8 Deprecation warnings

### DIFF
--- a/openid.php
+++ b/openid.php
@@ -187,7 +187,7 @@ class LightOpenID
         return $use_secure_protocol ? 'https://' : 'http://';
     }
 
-    protected function request_curl($url, $method='GET', $params=array(), $update_claimed_id)
+    protected function request_curl($url=null, $method='GET', $params=array(), $update_claimed_id=null)
     {
         $params = http_build_query($params, '', '&');
         $curl = curl_init($url . ($method == 'GET' && $params ? '?' . $params : ''));
@@ -317,7 +317,7 @@ class LightOpenID
         return $headers;
     }
 
-    protected function request_streams($url, $method='GET', $params=array(), $update_claimed_id)
+    protected function request_streams($url=null, $method='GET', $params=array(), $update_claimed_id=null)
     {
         if(!$this->hostExists($url)) {
             throw new ErrorException("Could not connect to $url.", 404);


### PR DESCRIPTION
Adds initial PHP8 support, making the library function w/ PHP8

PHP 8 deprecates required parameters after optional parameters in function/method signatures